### PR TITLE
Add Gemfile to enable using Bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'flexmock', '~> 1.3'
+gem 'test-unit', '~> 3.0'


### PR DESCRIPTION
Since flexmock is needed to run the unit tests, I think it's reasonable to have this gem declared in a Gemfile.
